### PR TITLE
Add to Exercise Log button functionality change

### DIFF
--- a/exlog_app/templates/exlog_app/ExerciseLog_Detail.html
+++ b/exlog_app/templates/exlog_app/ExerciseLog_Detail.html
@@ -6,7 +6,7 @@
     <div class="media-body">
 
         <div class="article-metadata">
-
+                
             <div class="row">
                 <div class="col-sm-8 col-12">
                     <h2 class="mt-1 mb-2">{{ exlog.date | date:"F d, Y"}} Workout</h2>
@@ -30,8 +30,7 @@
             <li class="unordered-list_item">
                 {{ exercise.exercise_name }}:
                 {% if exercise.num_sets != 0 %}
-                    {{ exercise.num_sets }}x
-                    {{ exercise.num_reps }}
+                    {{ exercise.num_sets }}x{{ exercise.num_reps }}
                     {{ exercise.exercise_weight }} lbs
                 {% endif %}
                 <a href="{% url 'exlog-update-exercise' exercise.id %}">Edit</a>

--- a/exlog_app/templates/exlog_app/ExerciseLog_Detail.html
+++ b/exlog_app/templates/exlog_app/ExerciseLog_Detail.html
@@ -30,7 +30,6 @@
             <li class="unordered-list_item">
                 {{ exercise.exercise_name }}:
                 {% if exercise.num_sets != 0 %}
-                    {{ exercise.exercise_name }}:
                     {{ exercise.num_sets }}x
                     {{ exercise.num_reps }}
                     {{ exercise.exercise_weight }} lbs

--- a/exlog_app/templates/exlog_app/base.html
+++ b/exlog_app/templates/exlog_app/base.html
@@ -8,6 +8,7 @@
 {% block stylesheets %}{% endblock stylesheets %}
 
 <main role="main" class="container">
+
   <div class="row">
 
     <div class="col-md-8">

--- a/exlog_app/templates/exlog_app/home.html
+++ b/exlog_app/templates/exlog_app/home.html
@@ -19,8 +19,7 @@
             <li class="unordered-list_item">
                 {{ exercise.exercise_name }}:
                 {% if exercise.num_sets != 0 %}
-                    {{ exercise.num_sets }}x
-                    {{ exercise.num_reps }}
+                    {{ exercise.num_sets }}x{{ exercise.num_reps }}
                     {{ exercise.exercise_weight }} lbs
                 {% endif %}
             </li>

--- a/exlog_app/templates/exlog_app/home.html
+++ b/exlog_app/templates/exlog_app/home.html
@@ -19,7 +19,6 @@
             <li class="unordered-list_item">
                 {{ exercise.exercise_name }}:
                 {% if exercise.num_sets != 0 %}
-                    {{ exercise.exercise_name }}:
                     {{ exercise.num_sets }}x
                     {{ exercise.num_reps }}
                     {{ exercise.exercise_weight }} lbs

--- a/exlog_app/views.py
+++ b/exlog_app/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.utils import timezone
 import datetime
 from django import forms
-from django.http import HttpResponseRedirect
+from django.http import *
 from .models import ExerciseLog, Exercise
 
 # List all Exercise Logs owned by the user
@@ -42,10 +42,6 @@ def add_from_recommender(request, exercise_name):
         # There already is an existing exercise log for the current day
         else:
             today_log = ExerciseLog.objects.filter(user=request.user.id, date=datetime.date.today())[exlog_count-1]
-    
-    
-    except IndexError:
-        pass
 
     except Exception as e:
         print('ERROR', e)
@@ -59,8 +55,11 @@ def add_from_recommender(request, exercise_name):
         exercise_weight=0,
     )
 
-    # Redirects to today's workout log after adding the exercise
-    return HttpResponseRedirect("/exlog/log/"+str(today_log.id))
+    # Stays on Exercises list page in case user wants to add more exercises to today's exercise log
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+    # Used to return to today's exercise log with the exercise added
+    # return HttpResponseRedirect("/exlog/log/"+str(today_log.id))
 
 # Detail View for Exercise Log objects
 class ExlogDetailView(DetailView):


### PR DESCRIPTION
Changed the "Add to Exercise Log" button on the Exercises page to stay on the Exercises page instead of redirecting to the Exercise Log with the new exercise added in case the user wants to add multiple Exercises before looking at their Exercise Log